### PR TITLE
feat(backend): implement MQTT-based configuration updates for devices and replace HTTP endpoints with MQTT communication for device configuration updates.

### DIFF
--- a/blabla.txt
+++ b/blabla.txt
@@ -1,0 +1,203 @@
+diff --git a/backend/main.go b/backend/main.go
+index b1132ed..ad214d4 100644
+--- a/backend/main.go
++++ b/backend/main.go
+@@ -1,73 +1,131 @@
+ package main
+ 
+ import (
+-	"encoding/json"
+-	"fmt"
+-	"net/http"
+-	"os"
+-	"path/filepath"
+-
+-	"github.com/gin-gonic/gin"
++    "encoding/json"
++    "fmt"
++    "io/ioutil"
++    "os"
++    "path/filepath"
++    "time"
++
++    MQTT "github.com/eclipse/paho.mqtt.golang"
++    "github.com/gin-gonic/gin"
+ )
+ 
++type DeviceInfo struct {
++    CommUnitID string `json:"CommUnitID"`
++}
++
++var devices map[string]DeviceInfo
++var devicesFile = "devices.json"
++var mqttClient MQTT.Client
++
+ func main() {
+-	router := gin.Default()
+-
+-	configDir := "./configs"
+-
+-	if _, err := os.Stat(configDir); os.IsNotExist(err) {
+-		os.Mkdir(configDir, os.ModePerm)
+-	}
+-
+-	router.GET("/getConfig", func(c *gin.Context) {
+-		commUnitID := c.Query("CommUnitID")
+-		if commUnitID == "" {
+-			c.JSON(http.StatusBadRequest, gin.H{"error": "CommUnitID not provided"})
+-			return
+-		}
+-
+-		configPath := filepath.Join(configDir, fmt.Sprintf("%s_config.json", commUnitID))
+-		if _, err := os.Stat(configPath); os.IsNotExist(err) {
+-			c.JSON(http.StatusNotFound, gin.H{"error": "Config file not found"})
+-			return
+-		}
+-
+-		configData, err := os.ReadFile(configPath)
+-		if err != nil {
+-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to read config file"})
+-			return
+-		}
+-
+-		var config interface{}
+-		if err := json.Unmarshal(configData, &config); err != nil {
+-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Invalid JSON in config file"})
+-			return
+-		}
+-
+-		c.JSON(http.StatusOK, config)
+-	})
+-
+-	router.POST("/postData", func(c *gin.Context) {
+-		var data map[string]interface{}
+-		if err := c.BindJSON(&data); err != nil {
+-			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid JSON"})
+-			return
+-		}
+-
+-		fmt.Printf("Received data: %v\n", data)
+-
+-		f, err := os.OpenFile("received_data.json", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+-		if err != nil {
+-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to write data"})
+-			return
+-		}
+-		defer f.Close()
+-
+-		dataBytes, _ := json.Marshal(data)
+-		f.WriteString(string(dataBytes) + "\n")
+-
+-		c.JSON(http.StatusOK, gin.H{"status": "Data received"})
+-	})
+-
+-	router.Run(":5000")
++    router := gin.Default()
++
++    configDir := "./configs"
++    if _, err := os.Stat(configDir); os.IsNotExist(err) {
++        os.Mkdir(configDir, os.ModePerm)
++    }
++
++    devices = make(map[string]DeviceInfo)
++    loadDevices()
++
++    initMQTTClient()
++
++    router.POST("/configs/:commUnitID", updateConfigHandler)
++
++    router.Run(":5000")
++}
++
++func initMQTTClient() {
++    opts := MQTT.NewClientOptions()
++    opts.AddBroker("tcp://your_mqtt_broker_ip:1883")
++    opts.SetClientID("backend_server")
++    opts.SetUsername("your_mqtt_username")
++    opts.SetPassword("your_mqtt_password")
++
++    mqttClient = MQTT.NewClient(opts)
++    if token := mqttClient.Connect(); token.Wait() && token.Error() != nil {
++        panic(token.Error())
++    }
++
++    fmt.Println("Connected to MQTT broker")
++}
++
++func loadDevices() {
++    if _, err := os.Stat(devicesFile); err == nil {
++        data, err := ioutil.ReadFile(devicesFile)
++        if err == nil {
++            json.Unmarshal(data, &devices)
++        }
++    }
+ }
++
++func saveDevices() error {
++    devicesBytes, err := json.MarshalIndent(devices, "", "  ")
++    if err != nil {
++        return err
++    }
++
++    tempDevicesFile := devicesFile + ".tmp"
++    if err := ioutil.WriteFile(tempDevicesFile, devicesBytes, 0644); err != nil {
++        return err
++    }
++
++    return os.Rename(tempDevicesFile, devicesFile)
++}
++
++func updateConfigHandler(c *gin.Context) {
++    commUnitID := c.Param("commUnitID")
++
++    var configData map[string]interface{}
++    if err := c.BindJSON(&configData); err != nil {
++        c.JSON(400, gin.H{"error": "Invalid JSON"})
++        return
++    }
++
++    configPath := filepath.Join("./configs", fmt.Sprintf("%s_config.json", commUnitID))
++    configBytes, err := json.MarshalIndent(configData, "", "  ")
++    if err != nil {
++        c.JSON(500, gin.H{"error": "Failed to marshal config data"})
++        return
++    }
++
++    tempConfigPath := configPath + ".tmp"
++    if err := ioutil.WriteFile(tempConfigPath, configBytes, 0644); err != nil {
++        c.JSON(500, gin.H{"error": "Failed to write temp config file"})
++        return
++    }
++
++    if err := os.Rename(tempConfigPath, configPath); err != nil {
++        c.JSON(500, gin.H{"error": "Failed to save config file"})
++        return
++    }
++
++    topic := fmt.Sprintf("comm_unit/%s/config", commUnitID)
++    token := mqttClient.Publish(topic, 1, false, configBytes)
++    token.Wait()
++    if token.Error() != nil {
++        c.JSON(500, gin.H{"error": "Failed to publish config via MQTT"})
++        return
++    }
++
++    fmt.Printf("Published config to topic %s\n", topic)
++
++    statusTopic := fmt.Sprintf("comm_unit/%s/config/status", commUnitID)
++    statusChan := make(chan string)
++    mqttClient.Subscribe(statusTopic, 1, func(client MQTT.Client, msg MQTT.Message) {
++        statusChan <- string(msg.Payload())
++    })
++
++    select {
++    case statusMsg := <-statusChan:
++        fmt.Printf("Received status from device %s: %s\n", commUnitID, statusMsg)
++        c.JSON(200, gin.H{"status": "Config updated and applied by device", "deviceStatus": statusMsg})
++    case <-time.After(10 * time.Second):
++        c.JSON(500, gin.H{"error": "Timeout waiting for device status"})
++    }
++
++    mqttClient.Unsubscribe(statusTopic)
++}
+\ No newline at end of file


### PR DESCRIPTION
- Remove HTTP GET /getConfig and POST /postData endpoints.
- Initialize an MQTT client to connect to the MQTT broker.
- Add a POST /configs/:commUnitID endpoint to accept configuration updates via HTTP.
- In `updateConfigHandler`, save the configuration to a file and publish it to the device via MQTT on the topic `comm_unit/{commUnitID}/config`.
- Subscribe to `comm_unit/{commUnitID}/config/status` to receive status updates from devices with a timeout mechanism.
- Update the data flow to leverage MQTT for both sending configurations and receiving status feedback.

This change aligns with the new data flow approach, simplifying communication by using MQTT exclusively for device interaction.

BREAKING CHANGE: Devices now receive configuration updates via MQTT instead of HTTP. Device firmware must be updated to subscribe to the new MQTT topics and handle configuration updates accordingly.
